### PR TITLE
Keep Float32Array instances and don't allocate unnecessary Array

### DIFF
--- a/src/utils/loadMixamoAnimation.ts
+++ b/src/utils/loadMixamoAnimation.ts
@@ -39,10 +39,10 @@ export function loadMixamoAnimation( url:string, vrm:VRM ) {
 
                     const threetrack = new THREE.QuaternionKeyframeTrack(
                         `${ vrmNodeName }.${ propertyName }`,
-                        Array.from(track.times),
-                        Array.from(track.values.map( ( v, i ) => (
+                        track.times,
+                        track.values.map( ( v, i ) => (
                              (vrm.meta?.version === '0' && (i % 2) === 0) ? -v : v
-                        ))),
+                        )),
                     )
 
                     //console.log(t)
@@ -52,10 +52,10 @@ export function loadMixamoAnimation( url:string, vrm:VRM ) {
                     //console.log("vector ",vrmNodeName)
                     const threetrack = new THREE.VectorKeyframeTrack(
                         `${ vrmNodeName }.${ propertyName }`,
-                        Array.from(track.times),
-                        Array.from(track.values.map( ( v, i ) => (
+                        track.times,
+                        track.values.map( ( v, i ) => (
                             ( ( vrm.meta?.version === '0' && ( i % 3 ) !== 1 ) ? -v : v ) * 0.01
-                        ))),
+                        )),
                     )
                     //const initialBone:THREE.Bone = BoneMap.get(vrmBoneName) as THREE.Bone
                     //console.log(threetrack,initialBone)


### PR DESCRIPTION
Hello, just came across your code while working on retargetting animations for different skeletons, I ended up writing my own function, but I wanted to mention those changes.
`track.times` and `track.values` are Float32Array instances originally.
If you use `Array.from()` you're creating an Array, not a Float32Array. Float32Array is more optimized in memory I guess although it probably doesn't make much difference on just a single animation.
If you want to do a copy you can use `new Float32Array(track.times),` but really here it's not even needed to create a copy, you can keep the original.
And `track.values.map` is already creating a new Float32Array instance, there is no need to do `Array.from` after that.